### PR TITLE
Fixed double gpu devices drawing bug on windows

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -83,6 +83,7 @@ int main (int, char**) {
 	std::cout << "Requesting adapter..." << std::endl;
 	Surface surface = glfwGetWGPUSurface(instance, window);
 	RequestAdapterOptions adapterOpts{};
+  adapterOpts.powerPreference = PowerPreference::HighPerformance;
 	adapterOpts.compatibleSurface = surface;
 	Adapter adapter = instance.requestAdapter(adapterOpts);
 	std::cout << "Got adapter: " << adapter << std::endl;


### PR DESCRIPTION
Fixed the issue #19 
Windows system could tend to select the integrated graphics device instead of a dedicated one to construct the WGPUAdapter object, which would cause wrong rendering results.
In this step, I can only get the right results on Linux because a dedicated GPU is default device when driver ready.
On Windows, in my case, the default choice is Intel integrated GPU, which causes the tricky problem.
