### PR TITLE
Update Application.cpp in step105

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -316,7 +316,6 @@ bool Application::initWindowAndDevice() {
 #else
 	m_swapChainFormat = TextureFormat::BGRA8Unorm;
 #endif
-	adapter.release();
 
 	// Add window callbacks
 	// Set the user pointer to be "this"


### PR DESCRIPTION
adapter.release() is called twice in Application::initWindowAndDevice(), which caused an exception and closed the app.  Deleted the adapter.release() on line 319, and the app now opens and runs properly.

System info: 
Windows 11, intel CPU & integrated GPU, Dawn using Vulkan backend.